### PR TITLE
Fix import path

### DIFF
--- a/coda/parser.py
+++ b/coda/parser.py
@@ -29,8 +29,7 @@
 import re
 import os
 import time
-from statement import Statement
-from coda.statement import MovementRecord, MovementRecordType, InformationRecord,\
+from coda.statement import Statement, MovementRecord, MovementRecordType, InformationRecord,\
     FreeCommunication
 
 


### PR DESCRIPTION
Import parser used to raise ImportError 

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-6a951fa34820> in <module>()
----> 1 from coda import parser
      2 import os
      3 import datetime as dt
      4 import pandas as pd

/Users/alexiseggermont/anaconda/lib/python3.5/site-packages/coda/parser.py in <module>()
     30 import os
     31 import time
---> 32 from statement import Statement
     33 from coda.statement import MovementRecord, MovementRecordType, InformationRecord,\
     34     FreeCommunication

ImportError: No module named 'statement'
```